### PR TITLE
Correct typo

### DIFF
--- a/systemd/install
+++ b/systemd/install
@@ -8,7 +8,7 @@ copy_files() {
 	rsync -rt --exclude=/.git --filter=':- .gitignore' $projdir/ $D
 	git archive HEAD $projdir | tar -xC $D
 }
-copy_files()
+copy_files
 
 (
 umask 077


### PR DESCRIPTION
It resulted in the /etc/rchain-perf-harness directory not being created.