### PR TITLE
Use different docker image for /bin/bash availability

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -57,7 +57,7 @@ pipeline:
       - echo $CONTRACT
       - echo $RNODE_IMAGE_VERSION
       - docker pull rchain/rnode:dev
-      - docker image tag rchain/rnode:dev rchain/rnode:for_drone_${DRONE_BUILD_NUMBER}
+      - ci/patch-image-with-docker-package.sh rchain/rnode:dev rchain/rnode:for_drone_${DRONE_BUILD_NUMBER}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     when:
@@ -85,7 +85,7 @@ pipeline:
       - /opt/docker/bin/rnode -c ./drone/config/bootstrap.toml run
 
   wait-for-bootstrap:
-    image: docker
+    image: rchain/rnode:for_drone_${DRONE_BUILD_NUMBER}
     commands:
       - until ci/is-container-log-line-present.sh _step_4 'Making a transition to ApprovedBlockRecievedHandler state.'; do echo $?; sleep 5; done
     volumes:
@@ -124,7 +124,7 @@ pipeline:
       - /opt/docker/bin/rnode -c ./drone/config/validator4.toml run
 
   wait-for-validators:
-    image: docker
+    image: rchain/rnode:for_drone_${DRONE_BUILD_NUMBER}
     commands:
       - until ci/is-container-log-line-present.sh _step_6 'Making a transition to ApprovedBlockRecievedHandler state.'; do echo $?; sleep 5; done
       - until ci/is-container-log-line-present.sh _step_7 'Making a transition to ApprovedBlockRecievedHandler state.'; do echo $?; sleep 5; done

--- a/ci/patch-image-with-docker-package.sh
+++ b/ci/patch-image-with-docker-package.sh
@@ -1,0 +1,20 @@
+#/bin/bash -ue
+
+
+main () {
+    if [[ $# -ne 2 ]]; then
+        echo "$0: wrong number of arguments; expected 2, got $#"
+        return 1
+    fi
+    local original_image=$1; shift
+    local output_image=$1; shift
+
+    local container_hash=$(docker run --detach "$original_image")
+    docker exec "$container_hash" apt update
+    docker exec "$container_hash" apt install --yes docker.io
+    docker commit "$container_hash" "$output_image"
+    docker stop "$container_hash"
+}
+
+
+main "$@"


### PR DESCRIPTION
Builds are failing because there's no `/bin/bash` in the `docker` docker image.
https://drone.perf.rchain-dev.tk/rchain/rchain-perf-harness/54/8