### PR TITLE
Restart hubot systemd unit on failure

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -210,3 +210,11 @@ pipeline:
       - /workdir/.ivy2
     volumes:
       - /tmp/cache:/cache
+
+  clean-up-docker-images:
+    image: docker
+    commands:
+      - docker rmi --force $(docker images | awk '$2 ~ /for_drone_[0-9]*/ { print $3 }')
+      - docker rmi --force $(docker images | awk '$2 ~ /DRONE-[0-9]*/ { print $3 }')
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/.drone.yml
+++ b/.drone.yml
@@ -214,7 +214,7 @@ pipeline:
   clean-up-docker-images:
     image: docker
     commands:
-      - docker rmi --force $(docker images | awk '$2 ~ /for_drone_[0-9]*/ { print $3 }')
-      - docker rmi --force $(docker images | awk '$2 ~ /DRONE-[0-9]*/ { print $3 }')
+      - docker images | awk "\$2 !~ /for_drone_$DRONE_BUILD_NUMBER/ { print }" | awk '$2 ~ /for_drone_[0-9]*/ { print $3 }' | xargs --no-run-if-empty docker rmi --force
+      - docker images | awk "\$2 !~ /DRONE-$DRONE_BUILD_NUMBER/ { print }" | awk '$2 ~ /DRONE-[0-9]*/ { print $3 }' | xargs --no-run-if-empty docker rmi --force
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/ci/patch-image-with-docker-package.sh
+++ b/ci/patch-image-with-docker-package.sh
@@ -3,6 +3,12 @@
 set -o nounset
 set -o errexit
 
+
+stop_container () {
+    [ -n "$container_hash" ] && docker stop "$container_hash"
+}
+
+
 main () {
     if [ $# -lt 3 ]; then
         echo "$0: wrong number of arguments; expected 3, got $#"
@@ -12,7 +18,9 @@ main () {
     output_image=$1; shift
     docker_package=$1; shift
 
+    trap stop_container EXIT
     container_hash=$(docker run --detach "$original_image")
+
     docker exec "$container_hash" apt update
     if [ "$docker_package" = docker.io ]; then
         docker exec "$container_hash" apt install --yes docker.io
@@ -24,7 +32,6 @@ main () {
         docker exec "$container_hash" apt install --yes docker-ce
     fi
     docker commit "$container_hash" "$output_image"
-    docker stop "$container_hash"
 }
 
 

--- a/systemd/hubot.service
+++ b/systemd/hubot.service
@@ -4,8 +4,7 @@ After=docker.service drone.service
 StopWhenUnneeded=true
 [Service]
 ExecStart=/usr/bin/docker run --rm --name rchain-hubot --env-file=/etc/rchain-perf-harness/hubot.env rchain/rchain-hubot
-# It ignores INT/TERM. It's crap.
 ExecStop=/usr/bin/docker rm -f rchain-hubot
-SuccessExitStatus=137
+Restart=on-failure
 [Install]
 WantedBy=rchain-perf-harness.target


### PR DESCRIPTION
```
Jan 24 15:13:35 perf-bootstrap docker[18172]: [Thu Jan 24 2019 22:13:35 GMT+0000 (UTC)] ERROR Error: Unhandled "error" event. ([object Object])
Jan 24 15:13:35 perf-bootstrap docker[18172]:   at Client.emit (events.js:186:19)
Jan 24 15:13:35 perf-bootstrap docker[18172]:   at WebSocketConnection.onError (/hubot/node_modules/discord.js/src/client/websocket/WebSocketConnection.js:374:17)
Jan 24 15:13:35 perf-bootstrap docker[18172]:   at WebSocket.onError (/hubot/node_modules/ws/lib/event-target.js:128:16)
Jan 24 15:13:35 perf-bootstrap docker[18172]:   at emitOne (events.js:116:13)
Jan 24 15:13:35 perf-bootstrap docker[18172]:   at WebSocket.emit (events.js:211:7)
Jan 24 15:13:35 perf-bootstrap docker[18172]:   at _receiver.cleanup (/hubot/node_modules/ws/lib/websocket.js:211:14)
Jan 24 15:13:35 perf-bootstrap docker[18172]:   at Receiver.cleanup (/hubot/node_modules/ws/lib/receiver.js:557:13)
Jan 24 15:13:35 perf-bootstrap docker[18172]:   at WebSocket.finalize (/hubot/node_modules/ws/lib/websocket.js:206:20)
Jan 24 15:13:35 perf-bootstrap docker[18172]:   at emitOne (events.js:116:13)
Jan 24 15:13:35 perf-bootstrap docker[18172]:   at TLSSocket.emit (events.js:211:7)
Jan 24 15:13:35 perf-bootstrap docker[18172]:   at emitErrorNT (internal/streams/destroy.js:66:8)
Jan 24 15:13:35 perf-bootstrap docker[18172]:   at _combinedTickCallback (internal/process/next_tick.js:139:11)
Jan 24 15:13:35 perf-bootstrap docker[18172]:   at process._tickCallback (internal/process/next_tick.js:181:9)
Jan 25 06:30:55 perf-bootstrap docker[7265]: Error: No such container: rchain-hubot
Jan 25 06:30:55 perf-bootstrap systemd[1]: hubot.service: Control process exited, code=exited status=1
Jan 25 06:30:55 perf-bootstrap systemd[1]: hubot.service: Failed with result 'exit-code'.
```