### PR TITLE
Try to make Hubot container killable

### DIFF
--- a/hubot/Dockerfile
+++ b/hubot/Dockerfile
@@ -10,4 +10,4 @@ USER root
 COPY rchainperfharness /usr/local/bin/
 USER hubot
 COPY scripts /hubot/scripts
-CMD hubot -a discord
+ENTRYPOINT ["hubot", "-a", "discord"]


### PR DESCRIPTION
Linux handles PID 1 specially. In particular, implicit signal handlers
are not invoked. CMD runs command in shell, which means that the shell
will be PID 1 that receive (and ignore) SIGTERM signal from systemd.

Make Hubot (i.e. node.js) PID 1 by using ENTRYPOINT and "array command",
and hope that it handles termination signals. (If not, we can always use
custom wrapper script, dump-init or tini.