### PR TITLE
Remove certbot submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "deployment/roles/certbot"]
-	path = deployment/roles/certbot
-	url = https://github.com/rchain/ansible-role-certbot.git
-	branch = perf-harness

--- a/deployment/site.yml
+++ b/deployment/site.yml
@@ -5,5 +5,4 @@
     - drone
     - hubot
     - metrics
-    - certbot
     - whiteblock


### PR DESCRIPTION
Instead, switch to using bastion host and rely on it to have HTTPS certs
configured.  Connection between the bastion host and perf-harness
happens over internal gcloud network.